### PR TITLE
isEdible fix loop fix

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal_vr.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal_vr.dm
@@ -87,6 +87,9 @@
 	if(vore_capacity != 0 && (vore_fullness >= vore_capacity)) // We're too full to fit them
 		ai_log("vr/wont eat [M] because I am too full", 3)
 		return 0
+	if(!M.isEdible)//Don't eat mobs that can't be eaten.
+		ai_log("vr/wont eat [M] because they aren't edible", 3)
+		return 0
 	return 1
 
 /mob/living/simple_animal/PunchTarget()


### PR DESCRIPTION
Prevents vore mobs from attempting to vore other mobs that are inedible. Without this they just got stuck in a loop trying to eat each other and deal no damage.